### PR TITLE
music sync update

### DIFF
--- a/source/ProtonPack/Configuration.h
+++ b/source/ProtonPack/Configuration.h
@@ -38,12 +38,12 @@
  *  Any settings saved in the EEPROM menu will overwrite these settings.
 */ 
 // For stock Haslab LEDs
-uint8_t i_cyclotron_leds = 12;
-uint8_t i_1984_cyclotron_leds[4] = { 1, 4, 7, 10 };
+//uint8_t i_cyclotron_leds = 12;
+//uint8_t i_1984_cyclotron_leds[4] = { 1, 4, 7, 10 };
 
 // For a 40 LED NeoPixel ring.
-//uint8_t i_cyclotron_leds = 40;
-//uint8_t i_1984_cyclotron_leds[4] = { 0, 10, 18, 28 };
+uint8_t i_cyclotron_leds = 40;
+uint8_t i_1984_cyclotron_leds[4] = { 0, 10, 18, 28 };
 
 // For a 20 LED Frutto Technology cyclotron.
 //uint8_t i_cyclotron_leds = 20;
@@ -88,7 +88,7 @@ bool b_powercell_colour_toggle = true;
  * Any settings saved in the EEPROM menu will overwrite these settings.
 */
 const unsigned int i_1984_delay = 1050;
-unsigned int i_2021_delay = 15; // 15 for stock Haslab LEDs. Change to 10 for the Frutto Technology Cyclotron and for a 40 LED NeoPixel ring.
+unsigned int i_2021_delay = 10; // 15 for stock Haslab LEDs. Change to 10 for the Frutto Technology Cyclotron and for a 40 LED NeoPixel ring.
 
 /*
   * Afterlife mode (2021) only.

--- a/source/ProtonPack/Configuration.h
+++ b/source/ProtonPack/Configuration.h
@@ -38,12 +38,12 @@
  *  Any settings saved in the EEPROM menu will overwrite these settings.
 */ 
 // For stock Haslab LEDs
-//uint8_t i_cyclotron_leds = 12;
-//uint8_t i_1984_cyclotron_leds[4] = { 1, 4, 7, 10 };
+uint8_t i_cyclotron_leds = 12;
+uint8_t i_1984_cyclotron_leds[4] = { 1, 4, 7, 10 };
 
 // For a 40 LED NeoPixel ring.
-uint8_t i_cyclotron_leds = 40;
-uint8_t i_1984_cyclotron_leds[4] = { 0, 10, 18, 28 };
+//uint8_t i_cyclotron_leds = 40;
+//uint8_t i_1984_cyclotron_leds[4] = { 0, 10, 18, 28 };
 
 // For a 20 LED Frutto Technology cyclotron.
 //uint8_t i_cyclotron_leds = 20;
@@ -88,7 +88,7 @@ bool b_powercell_colour_toggle = true;
  * Any settings saved in the EEPROM menu will overwrite these settings.
 */
 const unsigned int i_1984_delay = 1050;
-unsigned int i_2021_delay = 10; // 15 for stock Haslab LEDs. Change to 10 for the Frutto Technology Cyclotron and for a 40 LED NeoPixel ring.
+unsigned int i_2021_delay = 15; // 15 for stock Haslab LEDs. Change to 10 for the Frutto Technology Cyclotron and for a 40 LED NeoPixel ring.
 
 /*
   * Afterlife mode (2021) only.

--- a/source/ProtonPack/ProtonPack.ino
+++ b/source/ProtonPack/ProtonPack.ino
@@ -5596,11 +5596,8 @@ void checkWand() {
               packSerialSend(P_YEAR_AFTERLIFE);
             }
 
-            // Stop any music.
-            packSerialSend(P_MUSIC_STOP);
-            b_playing_music = false;
-            stopMusic();
-
+            // Sync the current music track.
+            // If music is already playing on a pack while a wand is reconnected, the wand will start playing music when the current track ends.
             packSerialSend(i_current_music_track);
 
             if(b_repeat_track == true) {

--- a/source/ProtonPack/ProtonPack.ino
+++ b/source/ProtonPack/ProtonPack.ino
@@ -5596,6 +5596,9 @@ void checkWand() {
               packSerialSend(P_YEAR_AFTERLIFE);
             }
 
+            // Stop any music. Mainly for when flashing while connected to a computer with a running wand.
+             packSerialSend(P_MUSIC_STOP);
+
             // Sync the current music track.
             // If music is already playing on a pack while a wand is reconnected, the wand will start playing music when the current track ends.
             packSerialSend(i_current_music_track);


### PR DESCRIPTION
If music is already playing on a pack while a wand is reconnected, the wand will start playing music when the current track ends.