### PR TITLE
Attenuator Functions

### DIFF
--- a/ATTENUATOR.md
+++ b/ATTENUATOR.md
@@ -66,7 +66,11 @@ It is worth noting that the device is meant to attach to the left shoulder strap
 	Height: 115mm
 	Depth: 38mm
 
-## Arduino Nano - Pin Reference
+## Arduino Nano - Standard Pinout Reference
+
+![](images/Arduino-nano-pinout.png)
+
+## Arduino Nano - Pin Connections
 
 The following is a diagram of the Arduino Nano pins from left and right, when oriented with the USB connection facing up (north).
 
@@ -88,7 +92,7 @@ The following is a diagram of the Arduino Nano pins from left and right, when or
 | Ground (Pack) | GND      |     | RX0      | to Pack TX1   |
 | +5V (Pack)    | VIN      |     | TX1      | to Pack RX1   |
 
-When connecting to the pack, the following wiring scheme was used with the 4-pin connector:
+When connecting to the pack, the following wiring scheme was used with the recommended 4-pin connector:
 
 	1 - GND (Black)
 	2 - 5V (Red)
@@ -181,15 +185,13 @@ Ideally, the device should be connected to the gpstar Proton Pack Controller whi
 * Left Toggle: Turns the pack on or off, similar to use of the switch under the Ion Arm
 * Right Toggle: Turns the LED's on the device on or off
 * Main Dial - Long Press: Alternates between two modes of operation
-	* Mode 1 (Default)
+	* Mode 1 (Default) - Indicated by a high buzzer tone
 		* Main Dial - Short Press: Starts or stops the current music track
+ 		* Main Dial - Double Press: Mutes or unmutes all pack/wand audio
 		* Main Dial - Turn CW/CCW: Adjusts the overall volume for pack/wand
-	* Mode 2
+	* Mode 2 - Indicated by a low buzzer tone
 		* Main Dial - Short Press: Advances to the next music track
+ 		* Main Dial - Double Press: Move to the previous music track
 		* Main Dial - Turn CW/CCW: Adjusts the effects volume for pack/wand
 
 Note that during an overheat warning, the device will emit sounds and vibrations in addition to lighting effects as the pack reaches a critical state. At this time the pack operator can turn the primary dial either direction to cancel the current warning. If the warning time is allowed to expire the the pack will enter the vent sequence.
-
-## Arduino Nano Pinout Reference
-
-![](images/Arduino-nano-pinout.png)

--- a/source/Attenuator/Attenuator.ino
+++ b/source/Attenuator/Attenuator.ino
@@ -131,19 +131,19 @@ void mainLoop() {
   if(switch_left.isPressed() || switch_left.isReleased()) {
     if(switch_left.getState() == LOW) {
       attenuatorSerialSend(A_TURN_PACK_ON);
+      b_pack_on = true;
     }
     else {
       attenuatorSerialSend(A_TURN_PACK_OFF);
+      b_pack_on = false;
     }
   }
 
   // Turn on the bargraph when certain conditions are met.
   // This supports pack connection or standalone operation.
-  if(b_pack_on || (switch_left.getState() == LOW && !b_wait_for_pack)) {
-    if(BARGRAPH_STATE == BG_OFF) {
+  if(b_pack_on) {
+    if(BARGRAPH_STATE == BG_OFF && !(b_overheating || b_pack_alarm)) {
       bargraphReset(); // Enable bargraph for use (resets variables and turns it on).
-    }
-    if(switch_left.getState() == LOW && !b_wait_for_pack){
       BARGRAPH_PATTERN = BG_POWER_RAMP; // Bargraph idling loop.
     }
   }
@@ -307,22 +307,37 @@ void checkRotaryPress() {
 
   // Determine whether the rotary dial (center button) got a short or long press.
   if(encoder_center.isPressed()) {
-    // Start a timer when the rotary dial is pressed.
-    ms_center_press.start(i_center_long_press_delay);
+    // Start all timers when the rotary dial is pressed.
+    ms_center_double_tap.start(i_center_double_tap_delay);
+    ms_center_long_press.start(i_center_long_press_delay);
     b_center_pressed = true;
   }
 
   if(b_center_pressed) {
-    if(encoder_center.isReleased() && ms_center_press.remaining() > 0) {
-      // If released and the timer is still running, then it was a short press.
+    if(encoder_center.isReleased() && i_press_count >= 1) {
+      // If released and we already counted 1 press, this is a "double tap".
+      CENTER_STATE = DOUBLE_PRESS;
+      b_center_pressed = false;
+      i_press_count = 0;
+      ms_center_double_tap.stop();
+    }
+    else if(encoder_center.isReleased() && ms_center_double_tap.remaining() > 0) {
+      // If released and the double-tap timer is still running, then ONLY increment count.
+      i_press_count++;
+    }
+    else if(ms_center_double_tap.remaining() < 1 && i_press_count == 1) {
+      // If the double-tap counter ran out with only a single press, this was a "short" press.
       CENTER_STATE = SHORT_PRESS;
       b_center_pressed = false;
-      ms_center_press.stop();
+      i_press_count = 0;
+      ms_center_double_tap.stop();
+      ms_center_long_press.stop();
     }
-    else if(ms_center_press.remaining() < 1) {
+    else if(ms_center_long_press.remaining() < 1) {
       // Consider a long-press event if the timer is run out before released.
       CENTER_STATE = LONG_PRESS;
       b_center_pressed = false;
+      i_press_count = 0;
     }
   }
 
@@ -331,16 +346,33 @@ void checkRotaryPress() {
       // Perform action for short press based on current menu level.
       switch(MENU_LEVEL) {
         case MENU_1:
-          // A short press should start/stop the music.
+          // A short, single press should start/stop the music.
           attenuatorSerialSend(A_MUSIC_START_STOP);
           useVibration(255, 200); // Give a quick nudge.
-          break;
+        break;
 
         case MENU_2:
-          // A short press should advance to the next track.
+          // A short, single press should advance to the next track.
           attenuatorSerialSend(A_MUSIC_NEXT_TRACK);
           useVibration(255, 200); // Give a quick nudge.
-          break;
+        break;
+      }
+    break;
+
+    case DOUBLE_PRESS:
+      // Perform action for double tap based on current menu level.
+      switch(MENU_LEVEL) {
+        case MENU_1:
+          // A double press should mute the pack and wand.
+          attenuatorSerialSend(A_TOGGLE_MUTE);
+          useVibration(255, 200); // Give a quick nudge.
+        break;
+
+        case MENU_2:
+          // A double press should move back to the previous track.
+          attenuatorSerialSend(A_MUSIC_PREV_TRACK);
+          useVibration(255, 200); // Give a quick nudge.
+        break;
       }
     break;
 

--- a/source/Attenuator/Bargraph.h
+++ b/source/Attenuator/Bargraph.h
@@ -172,11 +172,6 @@ void bargraphUpdate(uint8_t i_delay_divisor) {
   if(BARGRAPH_PATTERN == BG_POWER_RAMP ||
      BARGRAPH_PATTERN == BG_POWER_DOWN ||
      BARGRAPH_PATTERN == BG_POWER_UP) {
-    if(BARGRAPH_PATTERN == BG_POWER_RAMP){
-      // Set the initial direction for the power ramp (up).
-      BARGRAPH_PATTERN = BG_POWER_UP;
-    }
-
     // Use the current power level to set some global variables, such as the simulated maximum elements.
     // This will determine whether to ramp up or down, and must be called prior to the switch statement below.
     bargraphPowerCheck(POWER_LEVEL);
@@ -195,6 +190,10 @@ void bargraphUpdate(uint8_t i_delay_divisor) {
 
     // Animations should be based on a set pattern and logic here must only affect the bargraph device.
     switch(BARGRAPH_PATTERN) {
+      case BG_POWER_RAMP:
+        BARGRAPH_PATTERN = BG_POWER_UP; // Set the initial direction for the power ramp (up).
+      break;
+
       case BG_RAMP_UP:
         // This is intended to be a single action, ramping the bargraph up then stopping animations.
 

--- a/source/Attenuator/Header.h
+++ b/source/Attenuator/Header.h
@@ -126,9 +126,12 @@ const uint8_t rotary_debounce_time = 80;
 #define r_encoderB 3
 ezButton encoder_center(4); // For center-press on encoder dial.
 millisDelay ms_rotary_debounce; // Put some timing on the rotary so we do not overload the serial communication buffer.
-millisDelay ms_center_press;
+millisDelay ms_center_double_tap; // Timer for determinine when a double-tap was detected.
+millisDelay ms_center_long_press; // Timer for determining when a long press was detected.
 bool b_center_pressed = false;
+const unsigned int i_center_double_tap_delay = 300; // When to consider the center dial has a "double tap".
 const unsigned int i_center_long_press_delay = 600; // When to consider the center dial has a "long" press.
+int i_press_count = 0;
 int i_encoder_pos = 0;
 int i_val_rotary;
 int i_last_val_rotary;
@@ -137,7 +140,7 @@ int i_rotary_count = 0;
 /*
  * Define states for the rotary dial center press.
  */
-enum CENTER_STATES { NO_ACTION, SHORT_PRESS, LONG_PRESS };
+enum CENTER_STATES { NO_ACTION, SHORT_PRESS, DOUBLE_PRESS, LONG_PRESS };
 enum CENTER_STATES CENTER_STATE;
 enum MENU_LEVELS { MENU_1, MENU_2 };
 enum MENU_LEVELS MENU_LEVEL;

--- a/source/ProtonPack/Header.h
+++ b/source/ProtonPack/Header.h
@@ -126,14 +126,14 @@ millisDelay ms_cyclotron_switch_led;
 /* 
  *  State of the pack.
  */
-enum PACK_STATE { MODE_OFF, MODE_ON };
-enum PACK_STATE PACK_STATUS;
+enum PACK_STATES { MODE_OFF, MODE_ON };
+enum PACK_STATES PACK_STATE;
 
 /*
  * Pack action state.
  */
-enum PACK_ACTION_STATE { ACTION_IDLE, ACTION_OFF, ACTION_ACTIVATE };
-enum PACK_ACTION_STATE PACK_ACTION_STATUS;
+enum PACK_ACTION_STATES { ACTION_IDLE, ACTION_OFF, ACTION_ACTIVATE };
+enum PACK_ACTION_STATES PACK_ACTION_STATE;
 
 /*
  * Cyclotron lid LEDs control and lid detection.


### PR DESCRIPTION
This provides a new double-press action for the command dial which allows for 2 new abilities:
Menu 1: Double-press will mute all sounds from the pack and wand
Menu 2: Double-press will move back to the previous music track

Documentation for the device has been updated in kind.

In addition to the new functionality, I fixed some glitches which would occur during some fringe firing/alarm actions, as well as fixing behavior of the toggles in standalone mode when not paired with the pack.

There were some corrections made to the logic on the pack to support the previous track API. I had missed a compiler warning which made the original code non-functional. While in there, I did change the name of 2 enum values to maintain consistency with patterns used elsewhere.