### PR TITLE
Doc updates, fix shutdown sound

### DIFF
--- a/OPERATION.md
+++ b/OPERATION.md
@@ -78,7 +78,7 @@ The following features require the use of both the pack and wand replacement con
 **Video Game Mode (Default)**
 ![](images/OperationNeutrona4.jpg)
 
-- Pressing and holding the Barrel Wing Button while you are already throwing a Proton Stream with the Intensify button will initiate "Cross the Streams".
+- Pressing the Barrel Wing Button while you are already throwing a Proton Stream with the Intensify button will initiate "Cross the Streams".
 
 - The Barrel Wing Button at the end of the Neutrona Wand switches between these available firing modes while the wand is active and not throwing a stream:
 	1. Proton Stream (Default)
@@ -107,9 +107,7 @@ The following features require the use of both the pack and wand replacement con
 **Alternate Firing Modes: Cross The Streams (CTS) / Cross The Streams Mix (CTS Mix)**
 
 - The Barrel Wing Button at the end of the wand acts as a alternate fire mode button. When Cross The Streams is enabled, Video Game Modes are disabled and you will only have the Proton Stream.
-	- With Cross The Streams Mix, the Barrel Wing Button retains all its normal functionality unless you are already firing a Proton Stream.
 - The overheat features can only be triggered when holding the alternate fire mode button (Barrel Wing Button) when Cross The Streams mode is enabled.
-	- With Cross The Streams Mix, the overheat features match those of the normal video game modes.
 - Pressing both the Intensify and Barrel Wing Button at the same time enables the "Cross the Streams" (CTS) audio and visual effects. Releasing one of the 2 firing buttons will continue these effects.
 	- With Cross The Streams Mix, you need to hold both the Intensify and Barrel Wing Button at the same time. Releasing the Barrel Wing Button will end crossing the streams but continue firing a regular proton stream, and releasing Intensify will end firing completely.
 

--- a/source/NeutronaWand/Configuration.h
+++ b/source/NeutronaWand/Configuration.h
@@ -104,15 +104,15 @@ bool b_vent_light_control = false;
  * When set to true, the mode switch button to change firing modes changes to a alternate firing button.
  * Pressing this button together at the same time as the Intensify button does a cross the streams firing.
  * You can release one of the two firing buttons and the Neutrona Wand will still continue to cross the streams.
- * The video game firing modes will be disabled when you enable this.
+ * The video game firing modes will be disabled when you enable this, as will access to the sub menu using the mode switch button.
  * This can be enabled or disabled from the Neutrona Wand sub menu system.
 */
 bool b_cross_the_streams = false;
 
 /*
- * When set to true, the mode switch button to change firing modes changes to a alternate firing button.
  * When set to true, to cross the streams you must hold down the Barrel Wing Button while firing a Proton Stream.
  * Releasing the Barrel Wing Switch returns to Proton Stream, and releasing Intensify stops firing completely.
+ * b_cross_the_streams must be set to true as well in order to use this function.
  * This can be enabled or disabled from the Neutrona Wand sub menu system.
 */
 bool b_cross_the_streams_mix = false;

--- a/source/NeutronaWand/NeutronaWand.ino
+++ b/source/NeutronaWand/NeutronaWand.ino
@@ -208,6 +208,11 @@ void setup() {
   // Check if we should be in VGA mode or not.
   vgaModeCheck();
 
+  // Sanity check just in case a user forgot to enable CTS while enabling CTS Mix.
+  if(b_cross_the_streams_mix == true && b_cross_the_streams != true) {
+    b_cross_the_streams = true;
+  }
+
   #ifdef GPSTAR_NEUTRONA_WAND_PCB
     if(b_gpstar_benchtest == true) {
       b_no_pack = true;
@@ -2385,6 +2390,7 @@ void wandOff() {
   stopEffect(S_STASIS_START);
   stopEffect(S_MESON_START);
 
+  stopEffect(S_WAND_SHUTDOWN);
   playEffect(S_WAND_SHUTDOWN);
 
   // Turn off some timers.
@@ -2648,6 +2654,7 @@ void soundIdleStop() {
       case 1984:
       case 1989:
         if(WAND_ACTION_STATUS != ACTION_OFF) {
+          stopEffect(S_WAND_SHUTDOWN);
           playEffect(S_WAND_SHUTDOWN);
         }
       break;
@@ -2656,6 +2663,7 @@ void soundIdleStop() {
       default:
         if(b_pack_ribbon_cable_on == true) {
           if(WAND_ACTION_STATUS == ACTION_OVERHEATING || b_pack_alarm == true) {
+            //stopEffect(S_WAND_SHUTDOWN);
             //playEffect(S_WAND_SHUTDOWN);
 
             playEffect(S_AFTERLIFE_WAND_RAMP_DOWN_2_FADE_OUT, false, i_volume_effects - 1);


### PR DESCRIPTION
Updates documentation to match current state of functionality, fixes a bug that was allowing shutdown sounds to overlap if the user switched the wand on and off faster than the length of the wand shutdown sound.