### PR TITLE
Minor Wand changes

### DIFF
--- a/source/NeutronaWand/NeutronaWand.ino
+++ b/source/NeutronaWand/NeutronaWand.ino
@@ -5614,7 +5614,7 @@ void checkRotary() {
         case ACTION_EEPROM_MENU:
             // Counter clockwise.
             if(prev_next_code == 0x0b) {
-              if(i_wand_menu == 4 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              if(i_wand_menu == 4 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the wand barrel spectral custom colour.
                 if(i_spectral_wand_custom > 1 && i_spectral_wand_saturation_custom > 253) {
                   i_spectral_wand_custom--;
@@ -5632,15 +5632,15 @@ void checkRotary() {
 
                 wandBarrelSpectralCustomConfigOn();
               }
-              else if(i_wand_menu == 3 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 3 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Power Cell Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_POWERCELL_CUSTOM_DECREASE);
               }
-              else if(i_wand_menu == 2 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 2 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Cyclotron Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_CYCLOTRON_CUSTOM_DECREASE);
               }
-              else if(i_wand_menu == 1 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 1 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Inner Cyclotron Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_INNER_CYCLOTRON_CUSTOM_DECREASE);
               }
@@ -5654,7 +5654,7 @@ void checkRotary() {
 
             // Clockwise.
             if(prev_next_code == 0x07) {
-              if(i_wand_menu == 4 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              if(i_wand_menu == 4 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Wand Barrel Spectral custom colour.
                 if(i_spectral_wand_saturation_custom < 254) {
                   i_spectral_wand_saturation_custom++;
@@ -5679,15 +5679,15 @@ void checkRotary() {
 
                 wandBarrelSpectralCustomConfigOn();
               }
-              else if(i_wand_menu == 3 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 3 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Power Cell Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_POWERCELL_CUSTOM_INCREASE);
               }
-              else if(i_wand_menu == 2 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 2 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Cyclotron Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_CYCLOTRON_CUSTOM_INCREASE);
               }
-              else if(i_wand_menu == 1 && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value) {
+              else if(i_wand_menu == 1 && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW) {
                 // Change colour of the Inner Cyclotron Spectral custom colour.
                 wandSerialSend(W_SPECTRAL_INNER_CYCLOTRON_CUSTOM_INCREASE);
               }
@@ -5716,7 +5716,7 @@ void checkRotary() {
             wandSerialSend(W_VOLUME_SOUND_EFFECTS_DECREASE);
           }
           #ifdef GPSTAR_NEUTRONA_WAND_PCB
-            else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value && b_playing_music == true) {
+            else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW && b_playing_music == true) {
           #else
             else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && analogRead(switch_mode) > i_switch_mode_value && b_playing_music == true) {
           #endif
@@ -5783,7 +5783,7 @@ void checkRotary() {
             wandSerialSend(W_VOLUME_SOUND_EFFECTS_INCREASE);
           }
           #ifdef GPSTAR_NEUTRONA_WAND_PCB
-            else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && analogRead(switch_mode) < i_switch_mode_value && b_playing_music == true) {
+            else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && digitalRead(switch_mode) == LOW && b_playing_music == true) {
           #else
             else if(i_wand_menu == 3 && b_wand_menu_sub != true && switch_intensify.getState() == HIGH && analogRead(switch_mode) > i_switch_mode_value && b_playing_music == true) {
           #endif

--- a/source/NeutronaWand/NeutronaWand.ino
+++ b/source/NeutronaWand/NeutronaWand.ino
@@ -6125,12 +6125,12 @@ void wandExitMenu() {
   }
 #endif
 
-// Barrel Wing Button is connected to analog input.
-// PCB builds is pulled high.
-// Nano builds is pulled low.
+// Barrel Wing Button is connected to analog pin 6.
+// PCB builds is pulled high as digital input.
+// Nano builds is pulled low as analog input.
 bool switchMode() {
   #ifdef GPSTAR_NEUTRONA_WAND_PCB
-    if(analogRead(switch_mode) < i_switch_mode_value && ms_switch_mode_debounce.remaining() < 1 && b_switch_mode_pressed != true) {
+    if(digitalRead(switch_mode) == LOW && ms_switch_mode_debounce.remaining() < 1 && b_switch_mode_pressed != true) {
       ms_switch_mode_debounce.start(switch_debounce_time * 5);
 
       b_switch_mode_pressed = true;
@@ -6157,7 +6157,7 @@ bool switchMode() {
 // Check if the Barrel Wing Button is being held down or not.
 void switchModePressedReset() {
  #ifdef GPSTAR_NEUTRONA_WAND_PCB
-    if(analogRead(switch_mode) > i_switch_mode_value && b_switch_mode_pressed == true && ms_switch_mode_debounce.remaining() < 1) {
+    if(digitalRead(switch_mode) == HIGH && b_switch_mode_pressed == true && ms_switch_mode_debounce.remaining() < 1) {
       b_switch_mode_pressed = false;
     }
   #else
@@ -6167,12 +6167,12 @@ void switchModePressedReset() {
   #endif
 }
 
-// Barrel safety switch is connected to analog input.
-// PCB builds is pulled high.
-// Nano builds is pulled low.
+// Barrel safety switch is connected to analog pin 7.
+// PCB builds is pulled high as digital input.
+// Nano builds is pulled low as analog input.
 bool switchBarrel() {
   #ifdef GPSTAR_NEUTRONA_WAND_PCB
-    if(analogRead(switch_barrel) < i_switch_barrel_value) {
+    if(digitalRead(switch_barrel) == LOW) {
       return true;
     }
     else {
@@ -6216,7 +6216,7 @@ void afterLifeRamp1() {
 
 // Pack communication to the wand.
 void checkPack() {
-  if(wandComs.available()) {
+  if(wandComs.available() && b_no_pack != true) {
     wandComs.rxObj(comStruct);
 
     if(!wandComs.currentPacketID()) {
@@ -7024,11 +7024,13 @@ void checkPack() {
 }
 
 void wandSerialSend(int i_message) {
-  sendStruct.i = i_message;
-  sendStruct.s = W_COM_START;
-  sendStruct.e = W_COM_END;
+  if(b_no_pack != true) {
+    sendStruct.i = i_message;
+    sendStruct.s = W_COM_START;
+    sendStruct.e = W_COM_END;
 
-  wandComs.sendDatum(sendStruct);
+    wandComs.sendDatum(sendStruct);
+  }
 }
 
 #ifdef GPSTAR_NEUTRONA_WAND_PCB


### PR DESCRIPTION
This changes the gpstar build code to use digitalRead for the Barrel Wing Button and Barrel Safety Switch as a Mega 2560 has digital buffers on A6 and A7, unlike the Nano. Additionally this change disables both serial read and serial write if b_gpstar_benchtest is enabled, which should prevent any synchronization errors from the pack if a standalone-configured Wand is connected for some reason.