### PR TITLE
2021 cyclotron timer fix for 40 pixel rings

### DIFF
--- a/source/ProtonPack/Configuration.h
+++ b/source/ProtonPack/Configuration.h
@@ -172,7 +172,7 @@ const bool b_demo_light_mode = false;
  * 0 = quietest
  * 100 = loudest
 */
-const uint8_t STARTUP_VOLUME = 100;
+const uint8_t STARTUP_VOLUME = 5;
 
 /*
  * You can set the default music volume for your pack here.

--- a/source/ProtonPack/Configuration.h
+++ b/source/ProtonPack/Configuration.h
@@ -172,7 +172,7 @@ const bool b_demo_light_mode = false;
  * 0 = quietest
  * 100 = loudest
 */
-const uint8_t STARTUP_VOLUME = 5;
+const uint8_t STARTUP_VOLUME = 100;
 
 /*
  * You can set the default music volume for your pack here.

--- a/source/ProtonPack/ProtonPack.ino
+++ b/source/ProtonPack/ProtonPack.ino
@@ -1960,7 +1960,7 @@ void cyclotron2021(int cDelay) {
       i_current_ramp_speed = cDelay;
 
       int t_cDelay = cDelay;
-
+      
       switch(i_cyclotron_leds) {
         case OUTER_CYCLOTRON_LED_MAX:
         case FRUTTO_CYCLOTRON_LED_COUNT:
@@ -1968,6 +1968,10 @@ void cyclotron2021(int cDelay) {
         default:
           if(i_cyclotron_multiplier > 1) {
             t_cDelay = t_cDelay - i_cyclotron_multiplier;
+
+            if(t_cDelay < 1) {
+              t_cDelay = 1;
+            }
           }
         break;
       }
@@ -2043,7 +2047,7 @@ void cyclotron2021(int cDelay) {
     if(cDelay < 1) {
       cDelay = 1;
     }
-
+    
     if(b_clockwise == true) {
       if((i_cyclotron_led_value[i_led_cyclotron - cyclotron_led_start] == 0 && b_cyclotron_simulate_ring != true) || (i_cyclotron_led_value[i_led_cyclotron - cyclotron_led_start] == 0 && b_cyclotron_simulate_ring == true && i_cyclotron_matrix_led > 0)) {
         ms_cyclotron_led_fade_in[i_led_cyclotron - cyclotron_led_start].go(0);


### PR DESCRIPTION
Fixed bug for the 40 pixel ring in the cyclotron going off when the cyclotron speeds up too fast.